### PR TITLE
🐛 Fix : Reset Infinity scroll when rerendering

### DIFF
--- a/src/components/InfiniteScrollContainer.tsx
+++ b/src/components/InfiniteScrollContainer.tsx
@@ -12,6 +12,13 @@ const InfiniteScrollContainer = ({
   const [itemList, setItemList] = useState<[string, number][]>([]);
   const [countItem, setCountItem] = useState(12);
   const [ref, inView] = useInView();
+
+  useEffect(() => {
+    if (parseInt(sessionStorage.getItem('countHistory') || '12') === 0) {
+      setCountItem(12);
+    }
+  });
+
   useEffect(() => {
     setCountItem(parseInt(sessionStorage.getItem('countHistory') || '12'));
   }, []);

--- a/src/components/SearchContainer.tsx
+++ b/src/components/SearchContainer.tsx
@@ -33,6 +33,8 @@ const SearchContainer = ({
     setInputValue(e.target.value);
   };
   const handleOnAdd = (e: any) => {
+    sessionStorage.setItem('countHistory', '0');
+    sessionStorage.setItem('scrollHistory', '0');
     const value = e.currentTarget.textContent;
 
     if (value && inputValue !== '' && selectedList.includes(value) == false) {
@@ -45,6 +47,8 @@ const SearchContainer = ({
 
   const handleKeyUp = (e: any) => {
     if (e.key === 'Enter') {
+      sessionStorage.setItem('countHistory', '0');
+      sessionStorage.setItem('scrollHistory', '0');
       if (
         currentItem &&
         inputValue !== '' &&

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -18,6 +18,8 @@ const TagList = ({ selectedList, setSelectedList }: Props) => {
     // targetIndex의 원소를 삭제
     tempArr.splice(targetIndex, 1);
     setSelectedList(tempArr);
+    sessionStorage.setItem('countHistory', '0');
+    sessionStorage.setItem('scrollHistory', '0');
   };
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,9 +32,7 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     sessionStorage.setItem('selectedHistory', JSON.stringify(selectedList));
-  }, [selectedList]);
 
-  useEffect(() => {
     const newArr = [];
     for (let i = 0; i < selectedList.length; i++) {
       newArr.push(`${API_ENDPOINT}filter.php?i=${selectedList[i]}`);


### PR DESCRIPTION
- Tag List가 바뀔 때 페이지 크기, 스크롤 위치 초기화

To do
- 중복된 코드 리팩토링 필요
- 태그 추가 (handleOnAdd) 태그 삭제시 countHistory, scrollHistory를 0으로 초기화하고 있음
- 자동완성 마우스 클릭/엔터키 이벤트 리팩토링 필요